### PR TITLE
Repo Gardening: extend auto-labelling to add priority labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -54,6 +54,33 @@ body:
     attributes:
       label: Other information
       placeholder: Screenshots, additional logs, notes, etc.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Issue severity
+
+        Please provide details around how often the issue is reproducible & how many users are affected.
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: Reproducibility
+      options:
+        - Consistent
+        - Intermittent
+        - Once
+    validations:
+      required: true
+  - type: dropdown
+    id: users-affected
+    attributes:
+      label: Severity
+      description: How many users are impacted? A guess is fine.
+      options:
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
   - type: dropdown
     id: os
     attributes:

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-severity
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-severity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automatically add a Priority label based off the contents of an issue

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -3,6 +3,55 @@ const debug = require( '../../debug' );
 /* global GitHub, WebhookPayloadIssue */
 
 /**
+ * Find specific plugin impacted by issue, based off issue contents.
+ *
+ * @param {string} body - The issue content.
+ * @returns {string} Plugin concerned by issue.
+ */
+function findPlugin( body ) {
+	const regex = /###\sImpacted\splugin\n\n(\w*)\n/gm;
+
+	let match;
+	while ( ( match = regex.exec( body ) ) ) {
+		const [ , plugin ] = match;
+		return plugin;
+	}
+
+	return null;
+}
+
+/**
+ * Find priority of issue, based off issue contents.
+ *
+ * @param {string} body - The issue content.
+ * @returns {string} Priority of issue.
+ */
+function findPriority( body ) {
+	const regex = /###\sSeverity\n\n(.*)\n/gm;
+
+	let match;
+	while ( ( match = regex.exec( body ) ) ) {
+		const [ , severity ] = match;
+
+		switch ( severity ) {
+			case 'All':
+				return 'High';
+			case 'Some (< 50%)':
+				return 'High';
+			case 'Most (> 50%)':
+				return 'Normal';
+			case 'One':
+				return 'Low';
+			default:
+				// This includes the "_No response_" case, where one does not fill in the severity field.
+				return null;
+		}
+	}
+
+	return null;
+}
+
+/**
  * Add labels to newly opened issues.
  *
  * @param {WebhookPayloadIssue} payload - Issue event payload.
@@ -13,18 +62,29 @@ async function triageNewIssues( payload, octokit ) {
 	const { number, body } = issue;
 	const { owner, name } = repository;
 
-	const regex = /###\sImpacted\splugin\n\n(\w*)\n/gm;
-
-	let match;
-	while ( ( match = regex.exec( body ) ) ) {
-		const [ , plugin ] = match;
-		debug( `triage-new-issues: Adding label to issue #${ number }` );
+	// Find impacted plugin.
+	const impactedPlugin = findPlugin( body );
+	if ( null !== impactedPlugin ) {
+		debug( `triage-new-issues: Adding plugin label to issue #${ number }` );
 
 		await octokit.rest.issues.addLabels( {
 			owner: owner.login,
 			repo: name,
 			issue_number: number,
-			labels: [ `[Plugin] ${ plugin }` ],
+			labels: [ `[Plugin] ${ impactedPlugin }` ],
+		} );
+	}
+
+	// Find Priority.
+	const priority = findPriority( body );
+	if ( null !== priority ) {
+		debug( `triage-new-issues: Adding priority label to issue #${ number }` );
+
+		await octokit.rest.issues.addLabels( {
+			owner: owner.login,
+			repo: name,
+			issue_number: number,
+			labels: [ `[Pri] ${ priority }` ],
 		} );
 	}
 }

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/readme.md
@@ -1,9 +1,12 @@
 # Triage New Issues
 
-Add labels to newly opened issues to indicate what plugin is impacted by the issue.
+Add labels to newly opened issues to help triage the issue:
+
+1. Add a `[Plugin]` label if a specific label is impacted by the issue.
+2. Add a `[Pri]` label if we can determine the severity of the issue from the issue contents.
 
 This is best used in combination with GitHub [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms).
 
 ## Rationale
 
-Adding a label to new issues allows each plugin team to get quick notices of issues that need their attention, without having to wait for a nanual triage.
+Adding a label to new issues allows each team to get quick notices of issues that need their attention, without having to wait for a nanual triage. Priority also allows them to sort through the issues in the right order.


### PR DESCRIPTION
Let's automatically add a Priority label when information about the severity of the issue can be found in the contents of the issue.

Internal reference: pciE2j-18N-p2<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

