### PR TITLE
Triage: only add Priority label when not labelled yet.

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-triage-priority
+++ b/projects/github-actions/repo-gardening/changelog/update-triage-priority
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Triage: only add priority label when one does not exist yet.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -1,6 +1,22 @@
 const debug = require( '../../debug' );
+const getLabels = require( '../../get-labels' );
 
 /* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Check for Priority label on an issue
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasPriorityLabels( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in priority labels.
+	return !! labels.find( label => label.match( /^\[Pri\].*$/ ) );
+}
 
 /**
  * Find specific plugin impacted by issue, based off issue contents.
@@ -61,6 +77,7 @@ async function triageNewIssues( payload, octokit ) {
 	const { issue, repository } = payload;
 	const { number, body } = issue;
 	const { owner, name } = repository;
+	const ownerLogin = owner.login;
 
 	// Find impacted plugin.
 	const impactedPlugin = findPlugin( body );
@@ -68,7 +85,7 @@ async function triageNewIssues( payload, octokit ) {
 		debug( `triage-new-issues: Adding plugin label to issue #${ number }` );
 
 		await octokit.rest.issues.addLabels( {
-			owner: owner.login,
+			owner: ownerLogin,
 			repo: name,
 			issue_number: number,
 			labels: [ `[Plugin] ${ impactedPlugin }` ],
@@ -77,11 +94,12 @@ async function triageNewIssues( payload, octokit ) {
 
 	// Find Priority.
 	const priority = findPriority( body );
-	if ( null !== priority ) {
+	const hasPriorityLabel = await hasPriorityLabels( octokit, ownerLogin, name, number );
+	if ( null !== priority && ! hasPriorityLabel ) {
 		debug( `triage-new-issues: Adding priority label to issue #${ number }` );
 
 		await octokit.rest.issues.addLabels( {
-			owner: owner.login,
+			owner: ownerLogin,
 			repo: name,
 			issue_number: number,
 			labels: [ `[Pri] ${ priority }` ],


### PR DESCRIPTION
Follow-up from #24841

If someone has manually entered a Priority label when creating the issue, let's not add another Priority label.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

