### PR TITLE
Triage: update logic to follow issue priority matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -81,6 +81,23 @@ body:
         - Some (< 50%)
         - Most (> 50%)
         - All
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+  - type: textarea
+    id: workarounds-detail
+    attributes:
+      label: Workaround details
+      description: If you are aware of a workaround, please describe it below.
+      placeholder: |
+        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.
   - type: markdown
     attributes:
       value: |

--- a/projects/github-actions/repo-gardening/changelog/update-triage-priority-matrix
+++ b/projects/github-actions/repo-gardening/changelog/update-triage-priority-matrix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Triage: update priority logic to follow issue priority matrix.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -21,31 +21,29 @@ function findPlugin( body ) {
 }
 
 /**
- * Find priority of issue, based off issue contents.
+ * Figure out the priority of the issue, based off issue contents.
+ * Logic follows this priority matrix: pciE2j-oG-p2
  *
  * @param {string} body - The issue content.
  * @returns {string} Priority of issue.
  */
 function findPriority( body ) {
-	const regex = /###\sSeverity\n\n(.*)\n/gm;
+	// Look for priority indicators in body.
+	const priorityRegex = /###\sSeverity\n\n(?<severity>.*)\n\n###\sAvailable\sworkarounds\?\n\n(?<blocking>.*)\n/gm;
+	const priority = body.match( priorityRegex );
+	if ( priority ) {
+		const [ , severity = '', blocking = '' ] = priority;
 
-	let match;
-	while ( ( match = regex.exec( body ) ) ) {
-		const [ , severity ] = match;
-
-		switch ( severity ) {
-			case 'All':
-				return 'High';
-			case 'Some (< 50%)':
-				return 'High';
-			case 'Most (> 50%)':
-				return 'Normal';
-			case 'One':
-				return 'Low';
-			default:
-				// This includes the "_No response_" case, where one does not fill in the severity field.
-				return null;
+		if ( blocking === 'No and the platform is unusable' ) {
+			return severity === 'One' ? 'High' : 'BLOCKER';
+		} else if ( blocking === 'No but the platform is still usable' ) {
+			return 'High';
+		} else if ( blocking === 'Yes, difficult to implement' ) {
+			return severity === 'All' ? 'High' : 'Normal';
+		} else if ( blocking !== '' ) {
+			return severity === 'All' || severity === 'Most (> 50%)' ? 'Normal' : 'Low';
 		}
+		return null;
 	}
 
 	return null;


### PR DESCRIPTION
Instead of only relying on the severity declared in the issue body, let's add a new field (also used in Calypso) about the extent of the problem, and factor that when calculating the priority of an issue.

This follows an issue matrix described here: pciE2j-oG-p2

Internal reference: pciE2j-18N-p2#comment-1024

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

