### PR TITLE
Refactor: Move review link functionality from Jetpack class to dedicated file

### DIFF
--- a/projects/plugins/jetpack/changelog/test-a-backend-change
+++ b/projects/plugins/jetpack/changelog/test-a-backend-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: Internal refactor: move review link functionality to its own class file.
+

--- a/projects/plugins/jetpack/class-jetpack-review-link.php
+++ b/projects/plugins/jetpack/class-jetpack-review-link.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Jetpack Review Link - Adds a 5-star review link to the plugin row meta.
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Class to handle the review link in plugin row meta.
+ */
+class Jetpack_Review_Link {
+
+	/**
+	 * Initialize the review link functionality.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_filter( 'plugin_row_meta', array( __CLASS__, 'add_review_link' ), 10, 2 );
+	}
+
+	/**
+	 * Add a 5-star review link to the plugin row meta.
+	 *
+	 * @param array  $plugin_meta An array of the plugin's metadata.
+	 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+	 *
+	 * @return array
+	 */
+	public static function add_review_link( $plugin_meta, $plugin_file ) {
+		if ( $plugin_file !== 'jetpack/jetpack.php' ) {
+			return $plugin_meta;
+		}
+
+		$u    = get_current_user_id();
+		$site = get_site_url();
+
+		$plugin_meta[] = '<a href="https://jetpack.com/redirect?source=jetpack-plugin-review&site=' . esc_attr( $site ) . '&u=' . esc_attr( $u ) . '" target="_blank" rel="noopener noreferrer" title="' . esc_attr__( 'Rate Jetpack on WordPress.org', 'jetpack' ) . '" style="color: #ffb900">'
+			. str_repeat( '<span class="dashicons dashicons-star-filled" style="font-size: 16px; width:16px; height: 16px"></span>', 5 )
+			. '</a>';
+
+		return $plugin_meta;
+	}
+}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -743,8 +743,6 @@ class Jetpack {
 		// Actions for conditional recommendations.
 		add_action( 'plugins_loaded', array( 'Jetpack_Recommendations', 'init_conditional_recommendation_actions' ) );
 
-		// Add 5-star
-		add_filter( 'plugin_row_meta', array( $this, 'add_5_star_review_link' ), 10, 2 );
 		add_action( 'init', array( Deprecate::class, 'instance' ) );
 	}
 
@@ -6059,29 +6057,6 @@ endif;
 		}
 
 		return true;
-	}
-
-	/**
-	 * Add 5-star review link on the Jetpack Plugin meta, in the plugins list table (on the plugins page).
-	 *
-	 * @param array  $plugin_meta An array of the plugin's metadata.
-	 * @param string $plugin_file Path to the plugin file.
-	 *
-	 * @return array $plugin_meta An array of the plugin's metadata.
-	 */
-	public function add_5_star_review_link( $plugin_meta, $plugin_file ) {
-		if ( $plugin_file !== 'jetpack/jetpack.php' ) {
-			return $plugin_meta;
-		}
-
-		$u    = get_current_user_id();
-		$site = get_site_url();
-
-		$plugin_meta[] = '<a href="https://jetpack.com/redirect?source=jetpack-plugin-review&site=' . esc_attr( $site ) . '&u=' . esc_attr( $u ) . '" target="_blank" rel="noopener noreferrer" title="' . esc_attr__( 'Rate Jetpack on WordPress.org', 'jetpack' ) . '" style="color: #ffb900">'
-			. str_repeat( '<span class="dashicons dashicons-star-filled" style="font-size: 16px; width:16px; height: 16px"></span>', 5 )
-			. '</a>';
-
-		return $plugin_meta;
 	}
 
 	/**

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -79,5 +79,7 @@ add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 1
 add_filter( 'is_jetpack_site', '__return_true' );
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';
+require_once JETPACK__PLUGIN_DIR . 'class-jetpack-review-link.php';
 
 Jetpack::init();
+Jetpack_Review_Link::init();


### PR DESCRIPTION
 ## Proposed changes:
  * Extract the 5-star review link logic from `class.jetpack.php` into its own
  dedicated class (`Jetpack_Review_Link`) for better code organization.
  * This helps reduce the size of the main Jetpack class, which is already
  quite large.
  * No functional changes - the review link will continue to appear in the
  plugin row meta on the plugins page exactly as before.

  ### Other information:

  - [ ] Have you written new tests for your changes, if applicable?
  - [ ] Have you checked the E2E test CI results, and verified that your
  changes do not break them?
  - [ ] Have you tested your changes on WordPress.com, if applicable (if so,
  you'll see a generated comment below with a script to run)?

  ## Jetpack product discussion
  N/A - Internal refactor only.

  ## Does this pull request change what data or activity we track or use?
  No changes to tracking or data usage.

  ## Testing instructions:
  1. Go to **Plugins > Installed Plugins** in wp-admin
  2. Find the Jetpack plugin in the list
  3. Verify that the 5-star review link still appears in the plugin row meta
  (below the plugin description)
  4. Click the stars and verify it links to the WordPress.org review page

  ---
  Summary of changes made:
  - Created /projects/plugins/jetpack/class-jetpack-review-link.php with the
  Jetpack_Review_Link class
  - Removed the add_5_star_review_link method and its filter hook from
  class.jetpack.php
  - Added the require and init call in load-jetpack.php
  - Added a changelog entry