### PR TITLE
General: change the Jetpack plugin's name

### DIFF
--- a/projects/plugins/jetpack/changelog/update-plugin-name
+++ b/projects/plugins/jetpack/changelog/update-plugin-name
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+General: update the plugin's name

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Jetpack
+ * Plugin Name: Jetpack, with a new name
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic


### PR DESCRIPTION
> [!WARNING]
> This is a major change that will be visible to all users.

## Proposed changes:

Change the plugin's name from "Jetpack" to "Jetpack, with a new name "

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

* Go to the plugins menu
* Check the plugin's name
